### PR TITLE
Removed dependency of physical image for presence

### DIFF
--- a/src/aoc_fruit_detector/scripts/detectron_predictor/visualizer/aoc_visualizer.py
+++ b/src/aoc_fruit_detector/scripts/detectron_predictor/visualizer/aoc_visualizer.py
@@ -74,11 +74,11 @@ class AOCVisualizer(Visualizer):
             org_labels = [labels[k] for k in sorted_idxs] if labels is not None else None
             masks = [masks[idx] for idx in sorted_idxs] if masks is not None else None
             keypoints = keypoints[sorted_idxs] if keypoints is not None else None
-            boxes = boxes[sorted_idxs] if boxes is not None else None
+            #boxes = boxes[sorted_idxs] if boxes is not None else None # use if showing bboxes
             # uz: override colors, remove boxes and labels
             assigned_colors = [[0.0, 0.0, 1.0], [0.0, 1.0, 0.0],[1.0, 0.0, 0.0]]
             labels          = None #dont need labels
-
+            boxes           = None
         for i in range(num_instances):
 
             #uz: assign colors according to label text from metadata

--- a/src/aoc_fruit_detector/scripts/learner_predictor/learner_predictor.py
+++ b/src/aoc_fruit_detector/scripts/learner_predictor/learner_predictor.py
@@ -14,5 +14,9 @@ class LearnerPredictor(abc.ABC):
         pass
 
     @abc.abstractmethod
-    def get_predictions(self):
+    def get_predictions_message(self):
+        pass
+
+    @abc.abstractmethod
+    def get_predictions_image(self):
         pass

--- a/src/aoc_fruit_detector/scripts/predictor.py
+++ b/src/aoc_fruit_detector/scripts/predictor.py
@@ -72,10 +72,14 @@ def call_predictor():
                 prediction_json_output_file = ""
 
             if (__debug__):
-                json_annotation_message,predicted_image = det_predictor.get_predictions(rgb_image, prediction_json_output_file,
-                                                                                image_file_name)
+
+                json_annotation_message, predicted_image = det_predictor.get_predictions_image(rgb_image,
+                                                                                               prediction_json_output_file,
+                                                                                               image_file_name)
             else:
-                json_annotation_message, predicted_image = det_predictor.get_predictions(rgb_image)
+                dummy_image_id = 1
+                json_annotation_message, predicted_image = det_predictor.get_predictions_message(rgb_image,
+                                                                                                 dummy_image_id)
             # Use output json_annotation_message,predicted_image as per requirement
             # In Optimized (non-debug) mode predicted_image is None
 


### PR DESCRIPTION
made separate function for json message (optimized mode) as method overloading isn't allowed and dispatchables arent optimal for mult-threading removed bboxes
Now messages with RGBs will create json with image IDs and dummy file names as it's required by coco json