### PR TITLE
remove irrelevant and broken login action

### DIFF
--- a/.github/workflows/docker-build-image.yml
+++ b/.github/workflows/docker-build-image.yml
@@ -66,11 +66,3 @@ jobs:
             BASE_IMAGE=${{ matrix.base_image }}
             BRANCH=${{ env.BRANCH }}
             ROS_DISTRO=${{ matrix.ros_distro }}
-
-    - name: Docker Login AOC
-      if: ${{ github.event_name != 'pull_request' }}
-      uses: docker/login-action@v3
-      with:
-        registry: aoccr.zrok.lcas.group
-        username: ${{ secrets.AOC_REGISTRY_PUSHER }}
-        password: ${{ secrets.AOC_REGISTRY_TOKEN }}


### PR DESCRIPTION
This pull request includes changes to the `.github/workflows/docker-build-image.yml` file to remove an unnecessary Docker login step. The most important change is the removal of the Docker login action for the AOC registry, which was conditional on the event not being a pull request.

* [`.github/workflows/docker-build-image.yml`](diffhunk://#diff-74e40d7f0fc8b595deb87406b2891bd418e324fb95b01fb90d56400fa5c46ce3L69-L76): Removed the Docker login action for the AOC registry, which was not required at all.