### PR TITLE
Change QoS profile for subscriptions in fruit detection

### DIFF
--- a/scripts/fruit_detection.py
+++ b/scripts/fruit_detection.py
@@ -31,6 +31,8 @@ from geometry_msgs.msg import TransformStamped
 
 from scipy.spatial.transform import Rotation as R
 
+from rclpy.qos import qos_profile_sensor_data
+
 class FruitDetectionNode(Node):
     def __init__(self, non_ros_config_path):
         super().__init__('aoc_fruit_detector')
@@ -112,30 +114,25 @@ class FruitDetectionNode(Node):
             self.set_default_camera_model() # in case camera_info calibration message not available 
             
             # Declare subscribers
-            qos_profile = QoSProfile(
-                reliability=ReliabilityPolicy.BEST_EFFORT,
-                depth=1
-            )
-
             self.image_sub = self.create_subscription(
                 Image,
                 'camera/image_raw',
                 self.image_callback,
-                qos_profile
+                qos_profile=qos_profile_sensor_data
             )
 
             self.depth_sub = self.create_subscription(
                 Image,
                 'camera/depth',
                 self.depth_callback,
-                qos_profile
+                qos_profile=qos_profile_sensor_data
             )
 
             self.camera_info_sub = self.create_subscription(
                 CameraInfo,
                 'camera/camera_info',
                 self.camera_info_callback,
-                qos_profile
+                qos_profile=qos_profile_sensor_data
             )
 
             # Create and declare publishers


### PR DESCRIPTION
Updated QoS profile for image and camera info subscriptions to use sensor data profile.

st updates the QoS (Quality of Service) configuration for ROS2 subscriptions in the `FruitDetectionNode` class to use the standardized `qos_profile_sensor_data` profile. This change improves compatibility and reliability for handling sensor data streams in ROS2.

QoS configuration improvements:

* Replaced custom `QoSProfile` definitions for image, depth, and camera info subscribers with the standard `qos_profile_sensor_data` for all three subscriptions in `scripts/fruit_detection.py`. [[1]](diffhunk://#diff-1c2ecaa91147f74de15fad9378bad024b37229494a7bff1fd07b51a47dfb1f05R34-R35) [[2]](diffhunk://#diff-1c2ecaa91147f74de15fad9378bad024b37229494a7bff1fd07b51a47dfb1f05L115-R135)]
