### PR TITLE
Docs: clarify pretrained model configuration, metadata, and backbone usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,3 +103,25 @@ To get more information about the AOC Fruit Detector, please refer to [Wiki page
 ---
 
 [wiki_page]: https://github.com/LCAS/aoc_fruit_detector/wiki
+
+
+
+## Pretrained Models and Configuration
+
+### Model ↔ Class Mapping
+Each pretrained model expects a specific number of classes.
+When loading a model, `cfg.MODEL.ROI_HEADS.NUM_CLASSES` must match
+the number of classes used during training.
+
+| Model file                         | Task            | num_classes | Metadata file |
+|----------------------------------|-----------------|-------------|---------------|
+| aoc_ripeness.pth                  | Ripeness        | 2           | metadata.pkl  |
+| aoc_strawberry_class_fruit.pth    | Fruit detection | X           | Not provided  |
+
+⚠️ Currently, metadata files are only provided for the ripeness model.
+
+### Backbone Configuration
+The default backbone is:
+COCO-InstanceSegmentation/mask_rcnn_R_101_FPN_3x.yaml
+
+Other Detectron2 backbones may work, but have not been officially tested.


### PR DESCRIPTION
This PR improves documentation around pretrained model usage:

- Clarifies expected `num_classes` per model
- Documents current metadata availability
- Explains backbone configuration assumptions

Documentation-only change; no functional behavior modified.
Fixes part of #35.
